### PR TITLE
Added timestamp to logs. Logs end with newline so that output can be …

### DIFF
--- a/lenovo_fix.py
+++ b/lenovo_fix.py
@@ -15,6 +15,7 @@ from multiprocessing import cpu_count
 from platform import uname
 from threading import Event, Thread
 from time import time
+from datetime import datetime
 
 import configparser
 import dbus
@@ -697,7 +698,9 @@ def monitor(exit_event, wait):
             )
             stats2[power_plane] = '{:.1f} W'.format(energy_w)
         output2 = ('{:s}: {:s}'.format(label, stats2[label]) for label in stats2)
-        print('[{}] {}  ||  {}{}'.format(power['source'], ' - '.join(output), ' - '.join(output2), ' ' * 10), end='\r')
+        timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
+        print(timestamp,'[{}] {}  ||  {}{}'.format(power['source'], ' - '.join(output), ' - '.join(output2), ' ' * 10), end='\n')
+        sys.stdout.flush()
         exit_event.wait(wait)
 
 


### PR DESCRIPTION
…redirected to a file

Hello! 

I need to log the output like this:

`throttled/lenovo_fix.py --monitor 1 > throttled.log &`

I need the process to run in background and to redirect the output to file. For this I need

- timestamps
- new lines /n at the end of each record
- flush stdout 

Could you please merge it or perhaps add a new command-line option to redirect output to a file? 

Thanks a lot!
Jirka