### PR TITLE
Add Lenovo L490 to the supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ On systems where the EC doesn't reset the values (ex: ASUS Zenbook UX430UNR), th
 
 ### Tested hardware
 Other users have confirmed that the tool is also working for these laptops:
-- Lenovo T480, T480s, X1C5, X1C6, T580, L480, T470, X280, ThinkPad Anniversary Edition 25, E590 w/ RX 550X, P43s, E480, E580
+- Lenovo T480, T480s, X1C5, X1C6, T580, L490, L480, T470, X280, ThinkPad Anniversary Edition 25, E590 w/ RX 550X, P43s, E480, E580
 - Dell XPS 9365, 9370, Latitude 7390 2-in-1
 - Microsoft Surface Book 2
 


### PR DESCRIPTION
I'm using this fix successfully since ~6 month on my Lenovo L490 with these stable settings:
```
[GENERAL]
# Enable or disable the script execution
Enabled: True
# SYSFS path for checking if the system is running on AC power
Sysfs_Power_Path: /sys/class/power_supply/AC*/online

## Settings to apply while connected to Battery power
[BATTERY]
# Update the registers every this many seconds
Update_Rate_s: 30
# Max package power for time window #1
PL1_Tdp_W: 29
# Time window #1 duration
PL1_Duration_s: 28
# Max package power for time window #2
PL2_Tdp_W: 44
# Time window #2 duration
PL2_Duration_S: 0.002
# Max allowed temperature before throttling
Trip_Temp_C: 85
# Set cTDP to normal=0, down=1 or up=2 (EXPERIMENTAL)
cTDP: 0
# Disable BDPROCHOT (EXPERIMENTAL)
Disable_BDPROCHOT: False

## Settings to apply while connected to AC power
[AC]
# Update the registers every this many seconds
Update_Rate_s: 5
# Max package power for time window #1
PL1_Tdp_W: 44
# Time window #1 duration
PL1_Duration_s: 28
# Max package power for time window #2
PL2_Tdp_W: 44
# Time window #2 duration
PL2_Duration_S: 0.002
# Max allowed temperature before throttling
Trip_Temp_C: 95
# Set HWP energy performance hints to 'performance' on high load (EXPERIMENTAL)
HWP_Mode: True
# Set cTDP to normal=0, down=1 or up=2 (EXPERIMENTAL)
cTDP: 2
# Disable BDPROCHOT (EXPERIMENTAL)
Disable_BDPROCHOT: False

# All voltage values are expressed in mV and *MUST* be negative (i.e. undervolt)!
[UNDERVOLT.BATTERY]
# CPU core voltage offset (mV)
CORE: -100
# Integrated GPU voltage offset (mV)
GPU: -70
# CPU cache voltage offset (mV)
CACHE: -100
# System Agent voltage offset (mV)
UNCORE: -70
# Analog I/O voltage offset (mV)
ANALOGIO: 0

# All voltage values are expressed in mV and *MUST* be negative (i.e. undervolt)!
[UNDERVOLT.AC]
# CPU core voltage offset (mV)
CORE: -110
# Integrated GPU voltage offset (mV)
GPU: -80
# CPU cache voltage offset (mV)
CACHE: -110
# System Agent voltage offset (mV)
UNCORE: -80
# Analog I/O voltage offset (mV)
ANALOGIO: 0

# [ICCMAX.AC]
# # CPU core max current (A)
# CORE: 
# # Integrated GPU max current (A)
# GPU: 
# # CPU cache max current (A)
# CACHE: 

# [ICCMAX.BATTERY]
# # CPU core max current (A)
# CORE: 
# # Integrated GPU max current (A)
# GPU: 
# # CPU cache max current (A)
# CACHE: 
```
Before I applied this fix, under heavy load my CPU frequency was throttled down to under 1 GHz and the fan was never activated. Now I get 3.3GHz under full cpu load - 3 times faster than the default settings (under benchmarking conditions). Under realistic conditions in my daily work, like compiling java projects, my Laptop is more then 2 times faster than before - much more fun to work like before - so thanks a lot for this fix.

This should be proof enough to add the Lenovo L490 to the supported devices.