### PR TITLE
Reload when modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,11 +291,19 @@ This is an example output:
 [D] core 0 thermal status: reading valid = 1
 .....
 ```
+
+## Autoreload
+Auto reload config on changes (unless it's deleted) can be enabled/disabled in the config
+ 
+```
+[General]
+Autoreload = True
+```
+
 ## A word about manufacturer provided tooling
 Tools provided by your notebook manufacturer like [Dell Power Manager](https://www.dell.com/support/contents/us/en/04/article/product-support/self-support-knowledgebase/software-and-downloads/dell-power-manager) tend to persist their settings to the system board. If you ever had it running under Windows and activated a cool/quiet/silent/saving profile, this setting will still be active when running linux, throttling your system.
 
 > On my Dell Latitude 5591, not even a BIOS reset to manufacturar default killed the active `Quiet` profile
-
 
 ## Disclaimer
 This script overrides the default values set by Lenovo. I'm using it without any problem, but it is still experimental so use it at your own risk.

--- a/etc/lenovo_fix.conf
+++ b/etc/lenovo_fix.conf
@@ -3,6 +3,8 @@
 Enabled: True
 # SYSFS path for checking if the system is running on AC power
 Sysfs_Power_Path: /sys/class/power_supply/AC*/online
+# Auto reload config on changes
+Autoreload: True
 
 ## Settings to apply while connected to Battery power
 [BATTERY]

--- a/lenovo_fix.py
+++ b/lenovo_fix.py
@@ -542,7 +542,10 @@ def set_disable_bdprochot():
 
 
 def get_config_write_time():
-    return os.stat(args.config).st_mtime
+    try:
+        return os.stat(args.config).st_mtime
+    except FileNotFoundError:
+        return None
 
 
 def power_thread(config, regs, exit_event):
@@ -563,9 +566,9 @@ def power_thread(config, regs, exit_event):
                 for key, value in core_thermal_status.items():
                     log('[D] core {} thermal status: {} = {}'.format(index, key.replace("_", " "), value))
 
-        # Reload config when modified
+        # Reload config when modified (unless it no longer exists)
         config_write_time = get_config_write_time()
-        if last_config_write_time != config_write_time:
+        if config_write_time and last_config_write_time != config_write_time:
             last_config_write_time = config_write_time
             config = load_config()
             log('[I] Reloading changes.')

--- a/lenovo_fix.py
+++ b/lenovo_fix.py
@@ -548,6 +548,15 @@ def get_config_write_time():
         return None
 
 
+def reload_config():
+    config = load_config()
+    regs = calc_reg_values(get_cpu_platform_info(), config)
+    undervolt(config)
+    set_icc_max(config)
+    log('[I] Reloading changes.')
+    return config, regs
+
+
 def power_thread(config, regs, exit_event):
     try:
         mchbar_mmio = MMIO(0xFED159A0, 8)
@@ -570,8 +579,7 @@ def power_thread(config, regs, exit_event):
         config_write_time = get_config_write_time()
         if config_write_time and last_config_write_time != config_write_time:
             last_config_write_time = config_write_time
-            config = load_config()
-            log('[I] Reloading changes.')
+            config, regs = reload_config()
 
         # switch back to sysfs polling
         if power['method'] == 'polling':

--- a/lenovo_fix.py
+++ b/lenovo_fix.py
@@ -555,6 +555,7 @@ def reload_config():
     regs = calc_reg_values(get_cpu_platform_info(), config)
     undervolt(config)
     set_icc_max(config)
+    set_hwp(config.getboolean('AC', 'HWP_Mode', fallback=False))
     log('[I] Reloading changes.')
     return config, regs
 


### PR DESCRIPTION
Currently reloading changes to the config requires restarting the service.
This change reloads the config if it's been modified (as determined by the last modified time of the file), unless the file no longer exists.