### PR TITLE
lenovo_fix.service: Don't use deprecated logging options anymore

### DIFF
--- a/systemd/lenovo_fix.service
+++ b/systemd/lenovo_fix.service
@@ -6,8 +6,6 @@ Type=simple
 ExecStart=/opt/lenovo_fix/venv/bin/python3 /opt/lenovo_fix/lenovo_fix.py
 # Setting PYTHONUNBUFFERED is necessary to see the output of this service in the journal
 Environment=PYTHONUNBUFFERED=1
-StandardOutput=syslog
-StandardError=syslog
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
`StandardError` and `StandardOutput` don't support `syslog` anymore (they're long gone from the systemd manpages), and since 246, are migrated to `journal` under the hood.

As `journal` is also the default, don't configure it explicitly at all.

Related: https://github.com/NixOS/nixpkgs/pull/95353