### PR TITLE
README: Update GitHub repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ sudo rc-service lenovo_fix start
 ```
 sudo apt install git build-essential python3-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev python3-venv python3-wheel
 git clone https://github.com/erpalma/throttled.git
-sudo ./lenovo-throttling-fix/install.sh
+sudo ./throttled/install.sh
 ```
 If you own a X1C6 you can also check a tutorial for Ubuntu 18.04 [here](https://mensfeld.pl/2018/05/lenovo-thinkpad-x1-carbon-6th-gen-2018-ubuntu-18-04-tweaks/).
 
@@ -100,7 +100,7 @@ If you prefer to install from source, you can use the following commands.
 ```
 sudo dnf install python3-cairo-devel cairo-gobject-devel gobject-introspection-devel dbus-glib-devel python3-devel make libX11-devel
 git clone https://github.com/erpalma/throttled.git
-sudo ./lenovo-throttling-fix/install.sh
+sudo ./throttled/install.sh
 ```
 Feedback about Fedora installation is welcome.
 
@@ -109,7 +109,7 @@ User *brycecordill* reported that the following dependencies are required for in
 ```
 sudo zypper install gcc make python3-devel dbus-1-glib-devel python3-cairo-devel cairo-devel python3-gobject-cairo gobject-introspection-devel
 git clone https://github.com/erpalma/throttled.git
-sudo ./lenovo-throttling-fix/install.sh
+sudo ./throttled/install.sh
 ```
 
 ### Gentoo
@@ -126,7 +126,7 @@ systemctl start throttled.service
 sudo eopkg it -c system.devel
 sudo eopkg it git python3-devel dbus-glib-devel python3-cairo-devel libcairo-devel python3-gobject-devel
 git clone https://github.com/erpalma/throttled.git
-sudo ./lenovo-throttling-fix/install.sh
+sudo ./throttled/install.sh
 ```
 
 ### Void
@@ -138,7 +138,7 @@ sudo xbps-install -Sy gcc git python3-devel dbus-glib-devel libgirepository-deve
 
 git clone https://github.com/erpalma/throttled.git
 
-sudo ./lenovo-throttling-fix/install.sh
+sudo ./throttled/install.sh
 ```
 
 ### Uninstall
@@ -171,7 +171,7 @@ On Arch you should probably use `pacman -R lenovo-throttling-fix-git` instead.
 ### Update
 If you update the tool you should manually check your config file for changes or additional features and modify it accordingly. The update process is then as simple as:
 ```
-cd lenovo-throttling-fix
+cd throttled
 git pull
 sudo ./install.sh
 sudo systemctl restart lenovo_fix.service

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ sudo rc-service lenovo_fix start
 ### Debian/Ubuntu
 ```
 sudo apt install git build-essential python3-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev python3-venv python3-wheel
-git clone https://github.com/erpalma/lenovo-throttling-fix.git
+git clone https://github.com/erpalma/throttled.git
 sudo ./lenovo-throttling-fix/install.sh
 ```
 If you own a X1C6 you can also check a tutorial for Ubuntu 18.04 [here](https://mensfeld.pl/2018/05/lenovo-thinkpad-x1-carbon-6th-gen-2018-ubuntu-18-04-tweaks/).
@@ -99,7 +99,7 @@ sudo systemctl enable --now throttled
 If you prefer to install from source, you can use the following commands.
 ```
 sudo dnf install python3-cairo-devel cairo-gobject-devel gobject-introspection-devel dbus-glib-devel python3-devel make libX11-devel
-git clone https://github.com/erpalma/lenovo-throttling-fix.git
+git clone https://github.com/erpalma/throttled.git
 sudo ./lenovo-throttling-fix/install.sh
 ```
 Feedback about Fedora installation is welcome.
@@ -108,7 +108,7 @@ Feedback about Fedora installation is welcome.
 User *brycecordill* reported that the following dependencies are required for installing in openSUSE, tested on openSUSE 15.0 Leap.
 ```
 sudo zypper install gcc make python3-devel dbus-1-glib-devel python3-cairo-devel cairo-devel python3-gobject-cairo gobject-introspection-devel
-git clone https://github.com/erpalma/lenovo-throttling-fix.git
+git clone https://github.com/erpalma/throttled.git
 sudo ./lenovo-throttling-fix/install.sh
 ```
 
@@ -125,7 +125,7 @@ systemctl start throttled.service
 ```
 sudo eopkg it -c system.devel
 sudo eopkg it git python3-devel dbus-glib-devel python3-cairo-devel libcairo-devel python3-gobject-devel
-git clone https://github.com/erpalma/lenovo-throttling-fix.git
+git clone https://github.com/erpalma/throttled.git
 sudo ./lenovo-throttling-fix/install.sh
 ```
 
@@ -136,7 +136,7 @@ The installation itself will create a runit service as lenovo_fix, enable it and
 ```
 sudo xbps-install -Sy gcc git python3-devel dbus-glib-devel libgirepository-devel cairo-devel python3-wheel pkg-config make
 
-git clone https://github.com/erpalma/lenovo-throttling-fix.git
+git clone https://github.com/erpalma/throttled.git
 
 sudo ./lenovo-throttling-fix/install.sh
 ```


### PR DESCRIPTION
 Replaces `lenovo-throttling-fix` with `throttled` since it looks like the GitHub repo moved. While the old remote links work, curious folks (like me!) might see that and think they are downloading code from a different repository, and be hesitant to run it.