### PR TITLE
openrc fix

### DIFF
--- a/openrc/throttled
+++ b/openrc/throttled
@@ -1,5 +1,5 @@
-#!/usr/bin/openrc-run
-command="env python3 /usr/lib/throttled/throttled.py"
+#!/sbin/openrc-run
+command="/opt/throttled/venv/bin/python3 /opt/throttled/throttled.py"
 pidfile=${pidfile-/var/run/throttled.pid}
 description="Stop Intel throttling"
 command_background="yes"


### PR DESCRIPTION
This maintains consistency with the install.sh script by using the virtualenv that the script sets up. The original version was using a different interpreter and complained about missing imports. Additionally, the new shebang now points to the correct openrc-run executable. These were the only changes needed for this script to work on Gentoo.