### PR TITLE
Add python3-cairo-dev as requirement for ubuntu (21.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sudo rc-service throttled start
 
 ### Debian/Ubuntu
 ```
-sudo apt install git build-essential python3-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev python3-venv python3-wheel
+sudo apt install git build-essential python3-dev libdbus-glib-1-dev libgirepository1.0-dev libcairo2-dev python3-cairo-dev python3-venv python3-wheel
 git clone https://github.com/erpalma/throttled.git
 sudo ./throttled/install.sh
 ```


### PR DESCRIPTION
Adds missing requirement to  run `sudo ./throttled/install.sh successfully.`