### PR TITLE
Bump dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-configparser==5.2.0
-dbus-python==1.2.18
-PyGObject==3.42.2
+configparser==7.0.0
+dbus-python==1.3.2
+PyGObject==3.48.2


### PR DESCRIPTION
Fixes building with Python 3.13 distros

Tested on Fedora Rawhide
