### PR TITLE
Added LunarLake definition

### DIFF
--- a/throttled.py
+++ b/throttled.py
@@ -174,6 +174,7 @@ supported_cpus = {
     (6, 183, 1): 'RaptorLake-HX',
     (6, 186, 2): 'RaptorLake',
     (6, 186, 3): 'RaptorLake-U',
+    (6, 189, 1): 'LunarLake',
 }
 
 TESTMSR = False


### PR DESCRIPTION
Added LunarLake definition, it finally helped to make "Balanced" profile usable on my X1 Carbon Gen 13.

Before running throttled, only Power Save and Performance profiles were working as expected. Under Balanced profile CPU will stuck at 400 MHz no matter what.

Only thing I've changed in configuration is Disable_BDPROCHOT (True), BTW.