### PR TITLE
Only attempt changing currently enabled CPUs

### DIFF
--- a/throttled.py
+++ b/throttled.py
@@ -222,8 +222,11 @@ def warning(msg, oneshot=True, end='\n'):
         log_history.add(msg.strip())
 
 
+def get_msr_list():
+    return ['/dev/cpu/{:d}/msr'.format(int(x)) for x in os.listdir("/dev/cpu")]
+
 def writemsr(msr, val):
-    msr_list = ['/dev/cpu/{:d}/msr'.format(x) for x in range(cpu_count())]
+    msr_list = get_msr_list()
     if not os.path.exists(msr_list[0]):
         try:
             subprocess.check_call(('modprobe', 'msr'))
@@ -254,7 +257,7 @@ def readmsr(msr, from_bit=0, to_bit=63, cpu=None, flatten=False):
     assert cpu is None or cpu in range(cpu_count())
     if from_bit > to_bit:
         fatal('Wrong readmsr bit params')
-    msr_list = ['/dev/cpu/{:d}/msr'.format(x) for x in range(cpu_count())]
+    msr_list = get_msr_list()
     if not os.path.exists(msr_list[0]):
         try:
             subprocess.check_call(('modprobe', 'msr'))


### PR DESCRIPTION
Currently throttled assumes all CPUs are enabled, and if any CPUs are disabled using chcpu, then throttled Python script crashes with an exception.

This PR fixes this problem by checking which CPUs are enabled (disabled CPUs don't show up under /dev/cpu) and then only attempting to write MSR for those.