### PR TITLE
daemon: preserve fatal D-Bus exit status

### DIFF
--- a/tests/test_daemon_robustness.py
+++ b/tests/test_daemon_robustness.py
@@ -1,3 +1,4 @@
+import configparser
 import importlib.util
 import io
 import unittest
@@ -55,6 +56,35 @@ class DaemonRobustnessTests(unittest.TestCase):
                     throttled.power_thread({}, None)
 
         os_exit.assert_called_once_with(1)
+
+    def test_dbus_fatal_status_escapes_main(self):
+        throttled = load_throttled()
+        config = configparser.ConfigParser()
+        config.read_dict({'GENERAL': {'Enabled': 'True'}, 'AC': {'Update_Rate_s': '5'}})
+        parsed_args = SimpleNamespace(log=None, debug=False, config='/tmp/throttled.conf', monitor=None, force=True)
+        parser = mock.Mock()
+        parser.parse_args.return_value = parsed_args
+
+        with (
+            mock.patch.object(throttled, 'build_arg_parser', return_value=parser),
+            mock.patch.object(throttled, 'load_config', return_value=config),
+            mock.patch.object(throttled, 'set_msr_allow_writes'),
+            mock.patch.object(throttled, 'test_msr_rw_capabilities'),
+            mock.patch.object(throttled, 'is_on_battery', return_value=False),
+            mock.patch.object(throttled, 'get_cpu_platform_info', return_value={}),
+            mock.patch.object(throttled, 'calc_reg_values', return_value={}),
+            mock.patch.object(throttled, 'undervolt'),
+            mock.patch.object(throttled, 'set_icc_max'),
+            mock.patch.object(throttled, 'set_hwp'),
+            mock.patch.object(throttled, 'log'),
+            mock.patch.object(throttled, 'Thread'),
+            mock.patch.object(throttled, 'run_dbus_loop', new=mock.Mock(return_value=object())),
+            mock.patch.object(throttled.asyncio, 'run', side_effect=SystemExit(7)),
+        ):
+            with self.assertRaises(SystemExit) as exit_context:
+                throttled.main()
+
+        self.assertEqual(exit_context.exception.code, 7)
 
 
 if __name__ == '__main__':

--- a/throttled.py
+++ b/throttled.py
@@ -1554,7 +1554,7 @@ def main():
 
     try:
         asyncio.run(run_dbus_loop(state))
-    except (KeyboardInterrupt, SystemExit):
+    except KeyboardInterrupt:
         pass
     finally:
         exit_event.set()


### PR DESCRIPTION
### Summary

- Stop catching `SystemExit` around the asyncio D-Bus loop.
- Let fatal callback failures escape `main()` with their non-zero status so
  `Restart=on-failure` can revive the daemon.
- Add a regression that pins the `SystemExit` status escaping `main()`.

### Testing

- `python3 -m unittest tests.test_daemon_robustness`
- `python3 -m unittest discover -s tests`
