### PR TITLE
dbus: surface unexpected bus disconnects

### DIFF
--- a/tests/test_dbus_helpers.py
+++ b/tests/test_dbus_helpers.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 import unittest
 from pathlib import Path
@@ -59,6 +60,21 @@ class DBusHelperTests(unittest.TestCase):
         config = throttled.configparser.ConfigParser()
 
         self.assertIs(throttled.should_listen_for_resume(config), False)
+
+
+class DBusLoopTests(unittest.IsolatedAsyncioTestCase):
+    async def test_unexpected_disconnect_reaches_systemd(self):
+        throttled = load_throttled()
+        bus = mock.Mock()
+        bus.wait_for_disconnect = mock.AsyncMock(side_effect=ConnectionError('bus lost'))
+        context = {'bus': bus}
+
+        with mock.patch.object(throttled, 'setup_dbus_signal_handlers', return_value=context):
+            with self.assertRaisesRegex(ConnectionError, 'bus lost'):
+                await asyncio.wait_for(throttled.run_dbus_loop(object()), timeout=1)
+
+        bus.wait_for_disconnect.assert_awaited_once_with()
+        bus.disconnect.assert_called_once_with()
 
 
 if __name__ == '__main__':

--- a/throttled.py
+++ b/throttled.py
@@ -574,7 +574,7 @@ async def setup_dbus_signal_handlers(config_or_state):
 async def run_dbus_loop(config_or_state):
     context = await setup_dbus_signal_handlers(config_or_state)
     try:
-        await asyncio.Future()
+        await context['bus'].wait_for_disconnect()
     finally:
         context['bus'].disconnect()
 


### PR DESCRIPTION
### Summary

- Wait for dbus-fast's disconnect future instead of a bare future that never
  completes.
- Propagate an unexpected system-bus disconnect so systemd can restart the
  daemon rather than leaving it on a frozen power profile.
- Verify propagation and cleanup with an asynchronous regression test.

### Testing

- `python3 -m unittest tests.test_dbus_helpers`
- `python3 -m unittest discover -s tests`
