### PR TITLE
cli: reject invalid monitor intervals

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 import importlib.util
 import io
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 
@@ -41,6 +41,18 @@ class CLITests(unittest.TestCase):
 
         self.assertEqual(exit_context.exception.code, 0)
         self.assertTrue(output.getvalue().strip().endswith(f' {throttled.__version__}'))
+
+    def test_monitor_interval_must_be_finite_and_positive(self):
+        throttled = load_throttled()
+        parser = throttled.build_arg_parser()
+
+        for value in ('inf', 'nan', '0', '-1'):
+            with self.subTest(value=value), redirect_stderr(io.StringIO()):
+                with self.assertRaises(SystemExit) as exit_context:
+                    parser.parse_args(['--monitor', value])
+                self.assertEqual(exit_context.exception.code, 2)
+
+        self.assertEqual(parser.parse_args(['--monitor', '0.25']).monitor, 0.25)
 
 
 if __name__ == '__main__':

--- a/throttled.py
+++ b/throttled.py
@@ -1475,6 +1475,17 @@ def monitor(exit_event, wait):
         exit_event.wait(wait)
 
 
+def positive_finite_float(value):
+    """Parse a finite, positive command-line float."""
+    try:
+        number = float(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f'{value!r} is not a number') from e
+    if not math.isfinite(number) or number <= 0:
+        raise argparse.ArgumentTypeError(f'{value!r} must be finite and positive')
+    return number
+
+
 def build_arg_parser():
     """Create the command-line parser, disabling argparse's own color output when available."""
     try:
@@ -1487,7 +1498,7 @@ def build_arg_parser():
         '--monitor',
         metavar='update_rate',
         const=1.0,
-        type=float,
+        type=positive_finite_float,
         nargs='?',
         help='realtime monitoring of throttling causes (default 1s)',
     )


### PR DESCRIPTION
### Summary

- Reject non-finite, zero and negative `--monitor` intervals during argument
  parsing instead of accepting unusable values.
- Preserve valid positive floats.
- Avoid passing unusable wait intervals into the monitor loop.

### Testing

- `python3 -m unittest tests.test_cli`
- `python3 -m unittest discover -s tests`
