### PR TITLE
install: resolve python3 from PATH

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,7 @@ elif [ "$INIT" = "openrc" ]; then
 fi
 
 echo "Building virtualenv"
-/usr/bin/python3 -m venv "$INSTALL_DIR/venv"
+python3 -m venv "$INSTALL_DIR/venv"
 echo "Installing throttled and its Python dependencies"
 "$INSTALL_DIR/venv/bin/python3" -m pip install "$ROOT_DIR"
 rm -f "$INSTALL_DIR/requirements.txt" "$INSTALL_DIR/throttled.py" "$INSTALL_DIR/mmio.py"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -97,6 +97,11 @@ class PackagingTests(unittest.TestCase):
         self.assertIn('--init NAME', result.stdout)
         self.assertIn('--no-start', result.stdout)
 
+    def test_source_installer_uses_python_from_path(self):
+        installer_lines = INSTALL_SCRIPT.read_text().splitlines()
+
+        self.assertIn('python3 -m venv "$INSTALL_DIR/venv"', installer_lines)
+
     def test_packaging_scripts_are_executable(self):
         scripts = [
             STAGE_SCRIPT,


### PR DESCRIPTION
### Summary

- Create the source-install virtual environment with `python3` from `PATH`
  instead of assuming `/usr/bin/python3` exists.
- Keep the native-package wrapper unchanged: its `/usr/bin/python3` path is part
  of the package filesystem contract.
- Add a regression for the source installer contract.

### Testing

- `python3 -m unittest tests.test_packaging`
- `sh -n install.sh`
- `python3 -m unittest discover -s tests`
