### PR TITLE
monitor: avoid double-counting graphics power

### DIFF
--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -135,7 +135,7 @@ class ConfigValidationTests(unittest.TestCase):
         energy_values = {
             'MSR_INTEL_PKG_ENERGY_STATUS': iter((2**32 - 10, 5)),
             'MSR_PP1_ENERGY_STATUS': iter((100, 110)),
-            'MSR_DRAM_ENERGY_STATUS': iter((100, 110)),
+            'MSR_DRAM_ENERGY_STATUS': iter((100, 120)),
         }
 
         def readmsr(msr, *args, **kwargs):
@@ -154,6 +154,8 @@ class ConfigValidationTests(unittest.TestCase):
 
         output = next(call.args[0] for call in log.call_args_list if 'Package:' in call.args[0])
         self.assertIn('Package: 15.0 W', output)
+        self.assertIn('Graphics: 10.0 W', output)
+        self.assertIn('DRAM: 20.0 W', output)
         self.assertIn('Total: 35.0 W', output)
 
     def test_load_config_disables_malformed_power_limits(self):

--- a/throttled.py
+++ b/throttled.py
@@ -1462,7 +1462,9 @@ def monitor(exit_event, wait):
             energy_w = ((energy_j - prev_j) % rapl_counter_range) / (now - prev_t)
             prev_energy[power_plane] = (energy_j, now)
             stats2[power_plane] = f'{energy_w:.1f} W'
-            total += energy_w
+            # Package already includes Graphics; DRAM is a separate domain.
+            if power_plane != 'Graphics':
+                total += energy_w
 
         stats2['Total'] = f'{total:.1f} W'
 


### PR DESCRIPTION
### Summary

- Keep the PP1 Graphics reading visible as a diagnostic value.
- Exclude it from `Total` because package energy already contains the graphics
  domain; continue adding the separate DRAM domain.
- Use asymmetric Package, Graphics and DRAM readings to pin both the displayed
  domains and the Package + DRAM total.

### Testing

- `python3 -m unittest tests.test_config_validation.ConfigValidationTests.test_monitor_handles_rapl_counter_wraparound`
- `python3 -m unittest discover -s tests`
