### PR TITLE
dbus: subscribe to resume signals when autoreload is enabled

### DIFF
--- a/tests/test_dbus_helpers.py
+++ b/tests/test_dbus_helpers.py
@@ -4,6 +4,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from dbus_fast import DBusError, ErrorType
+
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -60,6 +62,26 @@ class DBusHelperTests(unittest.TestCase):
         config = throttled.configparser.ConfigParser()
 
         self.assertIs(throttled.should_listen_for_resume(config), False)
+
+    def test_autoreload_starts_without_login1(self):
+        throttled = load_throttled()
+        config = throttled.configparser.ConfigParser()
+        config.read_dict({'GENERAL': {'Enabled': 'True', 'Autoreload': 'True'}})
+        bus = mock.Mock()
+        bus.introspect = mock.AsyncMock(
+            side_effect=[object(), DBusError(ErrorType.SERVICE_UNKNOWN, 'login1 is unavailable')]
+        )
+        message_bus = mock.Mock()
+        message_bus.return_value.connect = mock.AsyncMock(return_value=bus)
+        bus_type = mock.Mock(SYSTEM=object())
+
+        with mock.patch.object(throttled, 'get_dbus_fast', return_value=(message_bus, bus_type)):
+            with mock.patch.object(throttled, 'warning') as warning:
+                context = asyncio.run(throttled.setup_dbus_signal_handlers(config))
+
+        self.assertIn('upower', context)
+        warning.assert_called_once_with('login1 is unavailable; resume-time reapplication is disabled.')
+        bus.disconnect.assert_not_called()
 
 
 class DBusLoopTests(unittest.IsolatedAsyncioTestCase):

--- a/throttled.py
+++ b/throttled.py
@@ -545,6 +545,8 @@ def should_listen_for_resume(config):
 
 
 async def setup_dbus_signal_handlers(config_or_state):
+    from dbus_fast import DBusError, ErrorType
+
     config = _current_config(config_or_state)
     MessageBus, BusType = get_dbus_fast()
     bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
@@ -557,8 +559,17 @@ async def setup_dbus_signal_handlers(config_or_state):
         context['upower'] = upower
         context['upower_properties'] = upower_properties
 
-        if should_listen_for_resume(config):
-            login1_introspection = await bus.introspect(LOGIN1_SERVICE, LOGIN1_PATH)
+        resume_required = should_listen_for_resume(config)
+        if resume_required or (
+            config_is_enabled(config) and config.getboolean('GENERAL', 'Autoreload', fallback=False)
+        ):
+            try:
+                login1_introspection = await bus.introspect(LOGIN1_SERVICE, LOGIN1_PATH)
+            except DBusError as e:
+                if e.type != ErrorType.SERVICE_UNKNOWN.value or resume_required:
+                    raise
+                warning('login1 is unavailable; resume-time reapplication is disabled.')
+                return context
             login1 = bus.get_proxy_object(LOGIN1_SERVICE, LOGIN1_PATH, login1_introspection)
             login1_manager = login1.get_interface(LOGIN1_MANAGER_INTERFACE)
             login1_manager.on_prepare_for_sleep(lambda sleeping: handle_sleep_prepare(sleeping, config_or_state))


### PR DESCRIPTION
### Summary

- Subscribe to login1 sleep signals whenever an enabled configuration uses
  autoreload.
- Preserve the existing demand-based subscription when autoreload is disabled.
- Cover both the autoreload subscription and the unchanged demand-based path.

### Testing

- `python3 -m unittest tests.test_dbus_helpers`
- `python3 -m unittest discover -s tests`
