### PR TITLE
power: reject zero-tick package limits

### DIFF
--- a/tests/test_msr_encoding.py
+++ b/tests/test_msr_encoding.py
@@ -89,8 +89,13 @@ class MsrEncodingTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(ValueError, 'PL1'):
             throttled._encode_pkg_power_limit(0x8000, 0, 1, 0)
+        with self.assertRaisesRegex(ValueError, 'PL1 must be at least one power-unit tick'):
+            throttled._encode_pkg_power_limit(0, 0, 1, 0)
         with self.assertRaisesRegex(ValueError, 'PL2'):
             throttled._encode_pkg_power_limit(1, 0, 0x8000, 0)
+        with self.assertRaisesRegex(ValueError, 'PL2 must be at least one power-unit tick'):
+            throttled._encode_pkg_power_limit(1, 0, 0, 0)
+        throttled._encode_pkg_power_limit(1, 0, 1, 0)
 
     def test_calculated_package_power_limit_rejects_unencodable_wattage(self):
         throttled = load_throttled()

--- a/throttled.py
+++ b/throttled.py
@@ -663,6 +663,8 @@ def _encode_pkg_power_limit(pl1, tw1, pl2, tw2):
     for name, value, mask in fields:
         if not isinstance(value, int) or not 0 <= value <= mask:
             raise ValueError(f'{name:s} value {value!r} does not fit its {mask.bit_length():d}-bit field.')
+        if name in ('PL1', 'PL2') and value == 0:
+            raise ValueError(f'{name:s} must be at least one power-unit tick, got {value!r}.')
         encoded[name] = value
     return (
         encoded['PL1']


### PR DESCRIPTION
### Summary

- Reject PL1 and PL2 fields that encode to zero, including sub-unit values that
  quantize to zero.
- Keep zero valid in the independent time-window fields.

### Testing

- `python3 -m unittest tests.test_msr_encoding`
- `python3 -m unittest discover -s tests`
