### PR TITLE
power: respect source when applying HWP mode

### DIFF
--- a/tests/test_power_source_flip.py
+++ b/tests/test_power_source_flip.py
@@ -41,6 +41,18 @@ class StopAfterWait:
 
 
 class PowerSourceFlipTests(unittest.TestCase):
+    def test_hwp_mode_respects_power_source(self):
+        throttled = load_throttled()
+        for source, options, expected in (
+            ('AC', {'HWP_Mode': True}, True),
+            ('BATTERY', {'HWP_Mode': True}, False),
+            ('AC', {'HWP_Mode': False}, False),
+            ('AC', {}, None),
+        ):
+            with self.subTest(source=source, options=options):
+                throttled.power['source'] = source
+                self.assertIs(throttled._hwp_mode(make_config({'AC': options})), expected)
+
     def test_resume_listener_checks_the_planes_each_key_actually_supports(self):
         throttled = load_throttled()
 

--- a/throttled.py
+++ b/throttled.py
@@ -1084,6 +1084,10 @@ def set_hwp(performance_mode):
             log(f'[D] HWP CPU {cpu:d} - write "{hwp_mode:#02x}" - read "{read_value:#02x}" - match {match}')
 
 
+def _hwp_mode(config):
+    return config.getboolean('AC', 'HWP_Mode', fallback=None) and power['source'] == 'AC'
+
+
 def set_disable_bdprochot():
     """Clear bit 0 of MSR_POWER_CTL to disable BDPROCHOT."""
     cur_val = readmsr('MSR_POWER_CTL', flatten=True)
@@ -1113,7 +1117,7 @@ def reload_config():
     regs = calc_reg_values(get_cpu_platform_info(), config)
     undervolt(config)
     set_icc_max(config)
-    set_hwp(config.getboolean('AC', 'HWP_Mode', fallback=None))
+    set_hwp(_hwp_mode(config))
     log('[I] Reloading changes.')
     return config, regs
 
@@ -1567,7 +1571,7 @@ def main():
 
     undervolt(config)
     set_icc_max(config)
-    set_hwp(config.getboolean('AC', 'HWP_Mode', fallback=None))
+    set_hwp(_hwp_mode(config))
 
     state = {'config': config, 'regs': regs}
 


### PR DESCRIPTION
### Summary

- With `HWP_Mode=True`, select performance on AC and the default on battery
  during startup and reload.
- Keep explicit `False` restoring the default and a missing option leaving HWP
  untouched.

### Testing

- `python3 -m unittest tests.test_power_source_flip`
- `python3 -m unittest discover -s tests`
