### PR TITLE
monitor: probe optional RAPL domains

### DIFF
--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -357,6 +357,53 @@ class ConfigValidationTests(unittest.TestCase):
         self.assertNotIn('UNDERVOLT', throttled.UNSUPPORTED_FEATURES)
         self.assertIn('ICCMAX', throttled.UNSUPPORTED_FEATURES)
 
+    def test_probe_omits_an_unreadable_monitor_power_domain(self):
+        throttled = load_throttled()
+        throttled.args.monitor = 1
+
+        def readmsr(msr, *args, **kwargs):
+            if msr == 'MSR_PP1_ENERGY_STATUS':
+                raise OSError
+            return 0
+
+        with mock.patch.object(throttled, 'get_undervolt', return_value={}):
+            with mock.patch.object(throttled, 'get_icc_max', return_value={}):
+                with mock.patch.object(throttled, 'readmsr', side_effect=readmsr):
+                    with mock.patch.object(throttled, 'writemsr'):
+                        with mock.patch.object(throttled, 'warning'):
+                            with mock.patch.object(throttled, 'log'):
+                                throttled.test_msr_rw_capabilities()
+
+        self.assertNotIn('Graphics', throttled.MONITOR_POWER_DOMAINS)
+        self.assertIn('Package', throttled.MONITOR_POWER_DOMAINS)
+        self.assertIn('DRAM', throttled.MONITOR_POWER_DOMAINS)
+
+        throttled.UNSUPPORTED_FEATURES.extend(('UNDERVOLT', 'ICCMAX'))
+        with (
+            mock.patch.object(throttled, 'readmsr', side_effect=readmsr),
+            mock.patch.object(throttled, 'log'),
+        ):
+            throttled.monitor(StopAfterWait(), 1)
+
+    def test_monitor_without_power_domains_skips_the_rapl_unit(self):
+        throttled = load_throttled()
+        forbidden_msrs = {'MSR_RAPL_POWER_UNIT', *throttled.MONITOR_POWER_DOMAINS.values()}
+        throttled.MONITOR_POWER_DOMAINS.clear()
+        throttled.UNSUPPORTED_FEATURES.extend(('UNDERVOLT', 'ICCMAX'))
+
+        def readmsr(msr, *args, **kwargs):
+            self.assertNotIn(msr, forbidden_msrs)
+            return 0
+
+        with (
+            mock.patch.object(throttled, 'readmsr', side_effect=readmsr),
+            mock.patch.object(throttled, 'log') as log,
+        ):
+            throttled.monitor(StopAfterWait(), 1)
+
+        output = next(call.args[0] for call in log.call_args_list if 'VCore:' in call.args[0])
+        self.assertIn('Total: 0.0 W', output)
+
     def test_set_icc_max_skips_the_mailbox_when_iccmax_is_unsupported(self):
         throttled = load_throttled()
         throttled.UNSUPPORTED_FEATURES.append('ICCMAX')

--- a/throttled.py
+++ b/throttled.py
@@ -258,6 +258,11 @@ MCHBAR_ADDRESS_MASKS_BY_PCI_DEVICE = {
 
 TESTMSR = False
 UNSUPPORTED_FEATURES = []
+MONITOR_POWER_DOMAINS = {
+    'Package': 'MSR_INTEL_PKG_ENERGY_STATUS',
+    'Graphics': 'MSR_PP1_ENERGY_STATUS',
+    'DRAM': 'MSR_DRAM_ENERGY_STATUS',
+}
 
 
 class bcolors:
@@ -1412,7 +1417,7 @@ def check_cpu():
 
 
 def test_msr_rw_capabilities():
-    """Probe undervolt, IccMax and HWP support; mark unavailable features as such."""
+    """Probe optional MSR features and mark unavailable ones as such."""
     global TESTMSR
     TESTMSR = True
     try:
@@ -1437,6 +1442,14 @@ def test_msr_rw_capabilities():
         except (IOError, OSError):
             warning('HWP seems not to be supported by your system, disabling.')
             UNSUPPORTED_FEATURES.append('HWP')
+
+        if args.monitor is not None:
+            for domain, msr in tuple(MONITOR_POWER_DOMAINS.items()):
+                try:
+                    readmsr(msr, cpu=0)
+                except (IOError, OSError):
+                    warning(f'{domain:s} power monitoring is not supported by your system, disabling.')
+                    del MONITOR_POWER_DOMAINS[domain]
     finally:
         TESTMSR = False
 
@@ -1444,19 +1457,15 @@ def test_msr_rw_capabilities():
 def monitor(exit_event, wait):
     """Live-display throttling causes and per-domain power until exit_event is set."""
     wait = max(0.1, wait)
-    rapl_power_unit = 0.5 ** readmsr('MSR_RAPL_POWER_UNIT', from_bit=8, to_bit=12, cpu=0)
-    # the RAPL energy counters are 32 bits wide and wrap every few minutes
-    rapl_counter_range = 2**32 * rapl_power_unit
-    power_plane_msr = {
-        'Package': 'MSR_INTEL_PKG_ENERGY_STATUS',
-        'Graphics': 'MSR_PP1_ENERGY_STATUS',
-        'DRAM': 'MSR_DRAM_ENERGY_STATUS',
-    }
-    prev_energy = {
-        'Package': (readmsr('MSR_INTEL_PKG_ENERGY_STATUS', cpu=0) * rapl_power_unit, time()),
-        'Graphics': (readmsr('MSR_PP1_ENERGY_STATUS', cpu=0) * rapl_power_unit, time()),
-        'DRAM': (readmsr('MSR_DRAM_ENERGY_STATUS', cpu=0) * rapl_power_unit, time()),
-    }
+    prev_energy = {}
+    if MONITOR_POWER_DOMAINS:
+        rapl_power_unit = 0.5 ** readmsr('MSR_RAPL_POWER_UNIT', from_bit=8, to_bit=12, cpu=0)
+        # the RAPL energy counters are 32 bits wide and wrap every few minutes
+        rapl_counter_range = 2**32 * rapl_power_unit
+        prev_energy = {
+            domain: (readmsr(msr, cpu=0) * rapl_power_unit, time())
+            for domain, msr in MONITOR_POWER_DOMAINS.items()
+        }
 
     if 'UNDERVOLT' in UNSUPPORTED_FEATURES:
         log('[D] Undervolt offsets: unsupported')
@@ -1481,8 +1490,8 @@ def monitor(exit_event, wait):
         vcore = readmsr('IA32_PERF_STATUS', from_bit=32, to_bit=47, cpu=0) / (2.0**13) * 1000
         stats2 = {'VCore': f'{vcore:.0f} mV'}
         total = 0.0
-        for power_plane in ('Package', 'Graphics', 'DRAM'):
-            energy_j = readmsr(power_plane_msr[power_plane], cpu=0) * rapl_power_unit
+        for power_plane, msr in MONITOR_POWER_DOMAINS.items():
+            energy_j = readmsr(msr, cpu=0) * rapl_power_unit
             now = time()
             prev_j, prev_t = prev_energy[power_plane]
             energy_w = ((energy_j - prev_j) % rapl_counter_range) / (now - prev_t)


### PR DESCRIPTION
### Summary

- Probe monitor energy counters in the existing main-thread MSR capability phase when `--monitor` is requested.
- Omit unreadable domains from initialization and sampling.
- Prevent unavailable RAPL counter MSRs from invoking the monitor-thread fatal path and terminating the whole daemon.

### Testing

- `python3 -m unittest tests.test_config_validation`
- `python3 -m unittest discover -s tests`
