### PR TITLE
monitor: use fixed DRAM unit on server CPUs

### DIFF
--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -42,6 +42,27 @@ class ConfigValidationTests(unittest.TestCase):
         self.addCleanup(os.unlink, tmp.name)
         return tmp.name
 
+    def monitor_output(self, throttled, cpuid):
+        energy_values = iter((2**32 - 1_000_000, 1_000_000))
+
+        def readmsr(msr, *args, **kwargs):
+            if msr == 'MSR_RAPL_POWER_UNIT':
+                return 14
+            if msr == 'MSR_DRAM_ENERGY_STATUS':
+                return next(energy_values)
+            return 0
+
+        throttled.MONITOR_POWER_DOMAINS = {'DRAM': 'MSR_DRAM_ENERGY_STATUS'}
+        throttled.UNSUPPORTED_FEATURES.extend(('UNDERVOLT', 'ICCMAX'))
+        with (
+            mock.patch.object(throttled, 'readmsr', side_effect=readmsr),
+            mock.patch.object(throttled, 'time', side_effect=(0, 1)),
+            mock.patch.object(throttled, 'log') as log,
+        ):
+            throttled.monitor(StopAfterWait(), 1, cpuid=cpuid)
+
+        return next(call.args[0] for call in log.call_args_list if 'DRAM:' in call.args[0])
+
     def test_load_config_survives_a_partial_undervolt_section(self):
         throttled = load_throttled()
         throttled.args.config = self.write_config(
@@ -157,6 +178,60 @@ class ConfigValidationTests(unittest.TestCase):
         self.assertIn('Graphics: 10.0 W', output)
         self.assertIn('DRAM: 20.0 W', output)
         self.assertIn('Total: 35.0 W', output)
+
+    def test_monitor_selects_dram_energy_unit_by_cpu_model(self):
+        cases = (
+            ('model 63', (6, 63, 2), 30.6),
+            ('model 79', (6, 79, 1), 30.6),
+            ('model 85', (6, 85, 4), 30.6),
+            ('model 87', (6, 87, 1), 30.6),
+            ('Broadwell-DE', (6, 86, 2), 30.6),
+            ('force', None, 122.1),
+        )
+
+        for name, cpuid, expected_watts in cases:
+            with self.subTest(name=name):
+                throttled = load_throttled()
+                output = self.monitor_output(throttled, cpuid)
+
+                self.assertIn(f'DRAM: {expected_watts:.1f} W', output)
+
+    def test_main_passes_checked_cpuid_to_monitor_thread(self):
+        throttled = load_throttled()
+        config = throttled.configparser.ConfigParser()
+        config.read_dict({'GENERAL': {'Enabled': 'True'}, 'AC': {'Update_Rate_s': '5'}})
+        parsed_args = SimpleNamespace(
+            log=None,
+            debug=False,
+            config='/tmp/throttled.conf',
+            monitor=0.5,
+            force=False,
+        )
+        parser = mock.Mock()
+        parser.parse_args.return_value = parsed_args
+        cpuid = (6, 85, 4)
+
+        with (
+            mock.patch.object(throttled, 'build_arg_parser', return_value=parser),
+            mock.patch.object(throttled, 'load_config', return_value=config),
+            mock.patch.object(throttled, 'check_kernel'),
+            mock.patch.object(throttled, 'check_cpu', return_value=cpuid),
+            mock.patch.object(throttled, 'set_msr_allow_writes'),
+            mock.patch.object(throttled, 'test_msr_rw_capabilities'),
+            mock.patch.object(throttled, 'is_on_battery', return_value=False),
+            mock.patch.object(throttled, 'get_cpu_platform_info', return_value={}),
+            mock.patch.object(throttled, 'calc_reg_values', return_value={}),
+            mock.patch.object(throttled, 'undervolt'),
+            mock.patch.object(throttled, 'set_icc_max'),
+            mock.patch.object(throttled, 'set_hwp'),
+            mock.patch.object(throttled, 'log'),
+            mock.patch.object(throttled, 'Thread') as thread,
+            mock.patch.object(throttled, 'run_dbus_loop', new=mock.Mock(return_value=object())),
+            mock.patch.object(throttled.asyncio, 'run'),
+        ):
+            throttled.main()
+
+        thread.assert_any_call(target=throttled.monitor, args=(mock.ANY, 0.5, cpuid))
 
     def test_load_config_disables_malformed_power_limits(self):
         throttled = load_throttled()

--- a/throttled.py
+++ b/throttled.py
@@ -207,6 +207,8 @@ supported_cpus = {
     (6, 204, 2): 'PantherLake',
 }
 
+FIXED_DRAM_ENERGY_UNIT_MODELS = {63, 79, 85, 86, 87}
+
 # MCHBAR belongs to the PCI host bridge, not to a CPUID signature. This is a
 # deliberately narrow allowlist: an unlisted device remains MSR-only.
 #
@@ -1454,16 +1456,18 @@ def test_msr_rw_capabilities():
         TESTMSR = False
 
 
-def monitor(exit_event, wait):
+def monitor(exit_event, wait, cpuid=None):
     """Live-display throttling causes and per-domain power until exit_event is set."""
     wait = max(0.1, wait)
     prev_energy = {}
     if MONITOR_POWER_DOMAINS:
         rapl_power_unit = 0.5 ** readmsr('MSR_RAPL_POWER_UNIT', from_bit=8, to_bit=12, cpu=0)
         # the RAPL energy counters are 32 bits wide and wrap every few minutes
-        rapl_counter_range = 2**32 * rapl_power_unit
+        energy_units = dict.fromkeys(MONITOR_POWER_DOMAINS, rapl_power_unit)
+        if 'DRAM' in energy_units and cpuid is not None and cpuid[0] == 6 and cpuid[1] in FIXED_DRAM_ENERGY_UNIT_MODELS:
+            energy_units['DRAM'] = 15.3e-6
         prev_energy = {
-            domain: (readmsr(msr, cpu=0) * rapl_power_unit, time())
+            domain: (readmsr(msr, cpu=0) * energy_units[domain], time())
             for domain, msr in MONITOR_POWER_DOMAINS.items()
         }
 
@@ -1491,10 +1495,11 @@ def monitor(exit_event, wait):
         stats2 = {'VCore': f'{vcore:.0f} mV'}
         total = 0.0
         for power_plane, msr in MONITOR_POWER_DOMAINS.items():
-            energy_j = readmsr(msr, cpu=0) * rapl_power_unit
+            energy_unit = energy_units[power_plane]
+            energy_j = readmsr(msr, cpu=0) * energy_unit
             now = time()
             prev_j, prev_t = prev_energy[power_plane]
-            energy_w = ((energy_j - prev_j) % rapl_counter_range) / (now - prev_t)
+            energy_w = ((energy_j - prev_j) % (2**32 * energy_unit)) / (now - prev_t)
             prev_energy[power_plane] = (energy_j, now)
             stats2[power_plane] = f'{energy_w:.1f} W'
             # Package already includes Graphics; DRAM is a separate domain.
@@ -1565,9 +1570,10 @@ def main():
         log('[I] Throttled is disabled in config file... Quitting. :(')
         return
 
+    cpuid = None
     if not args.force:
         check_kernel()
-        check_cpu()
+        cpuid = check_cpu()
 
     set_msr_allow_writes()
 
@@ -1596,7 +1602,7 @@ def main():
 
     monitor_thread = None
     if args.monitor is not None:
-        monitor_thread = Thread(target=monitor, args=(exit_event, args.monitor))
+        monitor_thread = Thread(target=monitor, args=(exit_event, args.monitor, cpuid))
         monitor_thread.daemon = True
         monitor_thread.start()
 


### PR DESCRIPTION
### Summary

- Carry the validated CPUID into the monitor thread.
- Use the fixed 15.3 microjoule DRAM energy unit on supported Intel server and
  Xeon Phi models, while preserving the unit reported by
  `MSR_RAPL_POWER_UNIT` for other models and domains.
- Apply counter wraparound using each monitored domain's own energy unit.

### Testing

- `python3 -m unittest tests.test_config_validation`
- `python3 -m unittest discover -s tests`
